### PR TITLE
Wip multiple changes

### DIFF
--- a/src/autofill.ts
+++ b/src/autofill.ts
@@ -13,8 +13,10 @@ Try saving your files or stage any new untracked files.\
 `;
 
 export const TOO_MANY_FILES = `\
-This extension currently only supports working with *one* changed file at a time.
-Stage just one file (or both it's old 'D' and new 'A' path) and try again.
+Too many file changes to process.
+
+This extension currently only supports working with *one* changed file at a time or just a
+*few* files. Stage just one file (or both it's old 'D' and new 'A' path) and try again.
 Or stash changes so that only one file change is left in the working tree.\
 `;
 
@@ -22,9 +24,9 @@ Or stash changes so that only one file change is left in the working tree.\
  * Generate and fill a commit message.
  *
  * Steps:
- *   1. Reading git commands output and currently filled message.
+ *   1. Read git command output and the message in the Git Extension commit message box.
  *   2. Generate a message.
- *   3. Push message to the Git Extension UI box.
+ *   3. Push message value to the commit message box.
  *
  * This is based on `prefixCommit` from the `git-prefix` extension.
  */

--- a/src/autofill.ts
+++ b/src/autofill.ts
@@ -37,7 +37,7 @@ export async function makeAndFillCommitMsg(repository: Repository) {
     vscode.window.showErrorMessage(NO_LINES);
     return;
   }
-  if (fileChanges.length > 1) {
+  if (fileChanges.length > 3) {
     vscode.window.showErrorMessage(TOO_MANY_FILES);
     return;
   }

--- a/src/generate/action.ts
+++ b/src/generate/action.ts
@@ -57,3 +57,10 @@ export function moveOrRenameFile(oldPath: string, newPath: string): string {
 
   return msg;
 }
+
+/**
+ * If all the files changed have the same action, return it. Otherwise return null value.
+ */
+export function reduceActions(actions: ActionKeys[]) {
+  return ACTION.A;
+}

--- a/src/generate/action.ts
+++ b/src/generate/action.ts
@@ -10,7 +10,7 @@
 import { ACTION, ROOT } from "../lib/constants";
 import { splitPath } from "../lib/paths";
 
-type ActionKeys = keyof typeof ACTION;
+export type ActionKeys = keyof typeof ACTION;
 
 /**
  * Extract single action from given X and Y actions.

--- a/src/generate/action.ts
+++ b/src/generate/action.ts
@@ -1,5 +1,11 @@
 /**
+ * Action module.
+ *
  * Phrase commit changes in words.
+ *
+ * This follows the git style of using `x` and `y`. See this project's docs for more info. Note that
+ * `first` and `second` are not appropriate names as `git status` and `git diff-index` behave
+ * differently.
  */
 import { ACTION, ROOT } from "../lib/constants";
 import { splitPath } from "../lib/paths";
@@ -9,11 +15,9 @@ type ActionKeys = keyof typeof ACTION;
 /**
  * Extract single action from given X and Y actions.
  *
- * NOT USED.
+ * NOT USED. But keep for future use with git status short output.
  *
- * This works for git status short output.
- *
- * "Modified" takes preferences over the others. There is no way here to combine update and move.
+ * "Modified" must take preference over the others. There is no way here to combine update and move.
  */
 export function lookupStatusAction(x: string, y: string): string {
   if (ACTION[y as ActionKeys] === ACTION.M) {
@@ -22,6 +26,9 @@ export function lookupStatusAction(x: string, y: string): string {
   return ACTION[x as ActionKeys];
 }
 
+/**
+ * Lookup the action for a given key (single character).
+ */
 export function lookupDiffIndexAction(x: string) {
   return ACTION[x as ActionKeys];
 }

--- a/src/generate/action.ts
+++ b/src/generate/action.ts
@@ -59,8 +59,16 @@ export function moveOrRenameFile(oldPath: string, newPath: string): string {
 }
 
 /**
+ * Reduce actions across files to a single action.
+ *
  * If all the files changed have the same action, return it. Otherwise return null value.
  */
 export function reduceActions(actions: ActionKeys[]) {
-  return ACTION.A;
+  const actionSet = new Set(actions);
+
+  if (actionSet.size !== 1) {
+    return ACTION.UNKNOWN;
+  }
+
+  return lookupDiffIndexAction(actions[0]);
 }

--- a/src/generate/message.ts
+++ b/src/generate/message.ts
@@ -55,10 +55,11 @@ export function oneChange(line: string) {
  * foo.txt and bar.txt'.
  */
 export function namedFiles(lines: string[]) {
-  const actions = lines.map(line => line[0]);
-  const reducedAction = reduceActions(actions as ActionKeys[]);
-
   const changes = lines.map(line => parseDiffIndex(line));
+
+  const actions = changes.map(item => item.x as ActionKeys);
+  const reducedAction = reduceActions(actions);
+
   const pathsChanged = changes.map(item => item.from);
   const fileList = humanList(pathsChanged);
 

--- a/src/generate/message.ts
+++ b/src/generate/message.ts
@@ -8,6 +8,13 @@ import { ACTION } from "../lib/constants";
 import { formatPath, humanList } from "../lib/paths";
 import { ActionKeys, lookupDiffIndexAction, moveOrRenameFile, reduceActions } from "./action";
 
+// TODO Find a type or move this or extend from it.
+type FileChange = {
+  actionChar: ACTION,
+  from: string
+  to?: string
+}
+
 /**
  * Make first letter of a string uppercase.
  *
@@ -36,6 +43,7 @@ function title(value: string) {
  * foo.txt'.
  */
 export function oneChange(line: string) {
+  // TODO This function should accept these separate params, to make it more usable.
   const { x: actionChar, from, to } = parseDiffIndex(line);
 
   const action = lookupDiffIndexAction(actionChar);
@@ -72,14 +80,18 @@ export function namedFiles(lines: string[]) {
   return `${title(reducedAction)} ${fileList}`;
 }
 
-// TODO Find a type or move this
-// Same as x and from but more readable.
-type FileChange = {
-  action: ACTION,
-  path: string
-}
 
+// Duplicating some logic in oneChange but not quiet. To avoid refactoring oneChange params for now
+// and because of title and move issues.
 export function actionNamePairs(fileChanges: FileChange[]) {
-  console.log(fileChanges);
-  return "Create foo.txt and update bar.txt";
+  // This is not working.
+  // Also maybe this transformation should in a separate function. Maybe even it is done before this function (needing a refactor)
+  const changeDescriptions = fileChanges.map(c => {
+    return {
+      actionChar: lookupDiffIndexAction(c.actionChar),
+      outputPath: formatPath(c.from),
+    };
+  }).map(d => `${d.actionChar} ${d.outputPath}`);
+
+  return humanList(changeDescriptions);
 }

--- a/src/generate/message.ts
+++ b/src/generate/message.ts
@@ -5,7 +5,7 @@
  */
 import { parseDiffIndex } from "../git/parseOutput";
 import { ACTION } from "../lib/constants";
-import { formatPath } from "../lib/paths";
+import { formatPath, humanList } from "../lib/paths";
 import { ActionKeys, lookupDiffIndexAction, moveOrRenameFile, reduceActions } from "./action";
 
 /**
@@ -58,7 +58,9 @@ export function namedFiles(lines: string[]) {
   const actions = lines.map(line => line[0]);
   const reducedAction = reduceActions(actions as ActionKeys[]);
 
-  const fileList = "foo.txt and bar.txt";
+  const changes = lines.map(line => parseDiffIndex(line));
+  const pathsChanged = changes.map(item => item.from);
+  const fileList = humanList(pathsChanged);
 
   if (reducedAction === ACTION.UNKNOWN) {
     return `Various changes to ${fileList}`;

--- a/src/generate/message.ts
+++ b/src/generate/message.ts
@@ -22,17 +22,18 @@ function title(value: string) {
 }
 
 /**
- * Prepare a commit message based on a single file change.
+ * Prepare a commit message based on a single changed file.
  *
  * A rename can be handled too - it just requires both the paths to be staged so that git collapses
  * D and A to a single R action.
- *
- * The output will be like 'Update foo.txt'.
  *
  * Using the variable name as 'from' is not really descriptive here but the logic works. It's also
  * possible to reverse 'from' and 'to' in `git status` and `git diff-index` output or handle just
  * the parseDiffIndex function to make sure 'to' is always set and 'from' is null if it is not a
  * move.
+ *
+ * Expects a single line string that came from a git command and returns a value like 'Update
+ * foo.txt'.
  */
 export function oneChange(line: string) {
   const { x: actionChar, from, to } = parseDiffIndex(line);
@@ -45,4 +46,14 @@ export function oneChange(line: string) {
   const outputPath = formatPath(from);
 
   return `${title(action)} ${outputPath}`;
+}
+
+/**
+ * Prepare a commit message using the names of a few changed files.
+ *
+ * Expects a multi-string string that came from a git command and returns a value like 'Update
+ * foo.txt and bar.txt'.
+ */
+export function namedFiles(lines: string[]) {
+  return "Create foo.txt and bar.txt";
 }

--- a/src/generate/message.ts
+++ b/src/generate/message.ts
@@ -61,7 +61,7 @@ export function namedFiles(lines: string[]) {
   const fileList = "foo.txt and bar.txt";
 
   if (reducedAction === ACTION.UNKNOWN) {
-    return fileList;
+    return `Various changes to ${fileList}`;
   }
 
   return `${title(reducedAction)} ${fileList}`;

--- a/src/generate/message.ts
+++ b/src/generate/message.ts
@@ -63,9 +63,23 @@ export function namedFiles(lines: string[]) {
   const pathsChanged = changes.map(item => item.from);
   const fileList = humanList(pathsChanged);
 
+  // TODO: Maybe remove this as a case. And move logic for the same action message to a new
+  // function.
   if (reducedAction === ACTION.UNKNOWN) {
     return `Various changes to ${fileList}`;
   }
 
   return `${title(reducedAction)} ${fileList}`;
+}
+
+// TODO Find a type or move this
+// Same as x and from but more readable.
+type FileChange = {
+  action: ACTION,
+  path: string
+}
+
+export function actionNamePairs(fileChanges: FileChange[]) {
+  console.log(fileChanges);
+  return "Create foo.txt and update bar.txt";
 }

--- a/src/generate/message.ts
+++ b/src/generate/message.ts
@@ -6,7 +6,7 @@
 import { parseDiffIndex } from "../git/parseOutput";
 import { ACTION } from "../lib/constants";
 import { formatPath } from "../lib/paths";
-import { lookupDiffIndexAction, moveOrRenameFile } from "./action";
+import { ActionKeys, lookupDiffIndexAction, moveOrRenameFile, reduceActions } from "./action";
 
 /**
  * Make first letter of a string uppercase.
@@ -51,9 +51,12 @@ export function oneChange(line: string) {
 /**
  * Prepare a commit message using the names of a few changed files.
  *
- * Expects a multi-string string that came from a git command and returns a value like 'Update
+ * Expects lines that came from a git command and returns a value like 'Update
  * foo.txt and bar.txt'.
  */
 export function namedFiles(lines: string[]) {
-  return "Create foo.txt and bar.txt";
+  const actions = lines.map(line => line[0]);
+  const reducedAction = reduceActions(actions as ActionKeys[]);
+
+  return `${title(reducedAction)} foo.txt and bar.txt`;
 }

--- a/src/generate/message.ts
+++ b/src/generate/message.ts
@@ -58,5 +58,11 @@ export function namedFiles(lines: string[]) {
   const actions = lines.map(line => line[0]);
   const reducedAction = reduceActions(actions as ActionKeys[]);
 
-  return `${title(reducedAction)} foo.txt and bar.txt`;
+  const fileList = "foo.txt and bar.txt";
+
+  if (reducedAction === ACTION.UNKNOWN) {
+    return fileList;
+  }
+
+  return `${title(reducedAction)} ${fileList}`;
 }

--- a/src/generate/semantic.ts
+++ b/src/generate/semantic.ts
@@ -1,5 +1,7 @@
 /**
- * Logic around semantic commit messages.
+ * Semantic module.
+ *
+ * Logic around semantic commit (aka conventional commit) messages.
  *
  * This can be used to check if all changes in a commit are related to 'chore' changes, 'docs'
  * changes, 'test' changes and so on.

--- a/src/git/cli.ts
+++ b/src/git/cli.ts
@@ -20,16 +20,16 @@ function execute(cwd: string, subcommand: string, options: string[] = []) {
 }
 
 /**
- * Run `git diff-index` with flags and return output.
+ * Run `git diff-index` with given flags and return output.
  *
  * This will return both staged and unstaged changes. Pass '--cached' to use staged changes only.
  * Always excludes untracked files.
  *
- * Removes any empty lines, whether because of no changes or just the way the command-line
- * data comes in or is split.
+ * Empty lines will be dropped - because of no changes or just the way the command-line data comes
+ * in or got split.
  *
- * Note the output already seems always to have no color from my testing, but the
- * no color flagged is added to be safe.
+ * The output already seems to never have color info, from my testing, but the no-color flagged is
+ * added still to be safe.
  */
 async function diffIndex(options: string[] = []): Promise<Array<string>> {
   const fullOptions = [
@@ -46,7 +46,9 @@ async function diffIndex(options: string[] = []): Promise<Array<string>> {
     console.debug("stderror for `git diff-index` command:", stderr);
   }
 
-  return stdout.split("\n").filter(line => line !== "");
+  const lines = stdout.split("\n");
+
+  return lines.filter(line => line !== "");
 }
 
 /**
@@ -56,7 +58,7 @@ async function diffIndex(options: string[] = []): Promise<Array<string>> {
  * Always excludes untracked files - make sure to stage a file so it becomes tracked, especially
  * in the case of a rename.
  *
- * Returns using the type of the underlying `diffIndex` function.
+ * Returns an array of strings, coming from the `diffIndex` function.
  */
 export async function getChanges() {
   const stagedChanges = await diffIndex([

--- a/src/git/parseOutput.ts
+++ b/src/git/parseOutput.ts
@@ -1,9 +1,13 @@
 /**
- * Parse git command output.
+ * Parse outut module.
+ *
+ * Handle text output from a git command.
  */
 import { FileChanges } from "./parseOutput.d";
 
 /**
+ * Parse status.
+ *
  * Parse a line coming from the `git status --short` command.
  */
 export function parseStatus(line: string): FileChanges {
@@ -25,6 +29,8 @@ export function parseStatus(line: string): FileChanges {
 }
 
 /**
+ * Parse diff index.
+ *
  * Parse a line produced by the `git diff-index` command.
  *
  * We keep `x` as a single letter, though the input might be 'R100 ...'.

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -27,8 +27,9 @@ export enum DESCRIPTION {
 /**
  * Describe actions in commit message sentences.
  *
- * These are based on GitHub syntax as in DESCRIPTION above. But in the active voice here and they
- * will be used for the message for the extension output.
+ * These are based on GitHub syntax as in DESCRIPTION above, except the values are in the active
+ * voice and not past tense, to fit the conventional commit style. Plus 'update' is used as a more
+ * natural word than 'modify'.
  *
  * Note that 'move' will be included in 'rename', unless behavior is used later in this project to
  * determine a move with different logic.

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -27,8 +27,8 @@ export enum DESCRIPTION {
 /**
  * Describe actions in commit message sentences.
  *
- * These were set up for this extension, based on GitHub syntax as in DESCRIPTION above but in the
- * active voice here.
+ * These are based on GitHub syntax as in DESCRIPTION above. But in the active voice here and they
+ * will be used for the message for the extension output.
  *
  * Note that 'move' will be included in 'rename', unless behavior is used later in this project to
  * determine a move with different logic.
@@ -38,7 +38,8 @@ export enum ACTION {
   A = "create",
   D = "delete",
   R = "rename",
-  C = "copy"
+  C = "copy",
+  UNKNOWN = ""
 }
 
 /**

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,8 +4,14 @@
 // Human-friendly description of path for use in commit messages.
 export const ROOT = "repo root";
 
-// Mapping of change description in git status (or diff-index).
-// The keys are for --short output.
+/**
+ * Mapping of change description.
+ *
+ * Based on the git docs for using `git status` or `git diff-index`. The keys are for `--short`
+ * output. The values are the human-readable values from the standard long output.
+ *
+ * I've never seen 'copied' in real life I don't think but it is included anyway for completeness.
+ */
 export enum DESCRIPTION {
   " " = "unmodified",
   M = "modified",
@@ -19,11 +25,13 @@ export enum DESCRIPTION {
 }
 
 /**
- * Labels to describe actions in commit message sentences.
+ * Describe actions in commit message sentences.
  *
- * These were setup for this extension, based on GitHub syntax.
- * Note move is included in rename, unless behavior is used to determine a move with
- * different logic.
+ * These were set up for this extension, based on GitHub syntax as in DESCRIPTION above but in the
+ * active voice here.
+ *
+ * Note that 'move' will be included in 'rename', unless behavior is used later in this project to
+ * determine a move with different logic.
  */
 export enum ACTION {
   M = "update",
@@ -34,7 +42,9 @@ export enum ACTION {
 }
 
 /**
- * Based on <type> from conventional commits specification.
+ * Conventional commits mapping.
+ *
+ * Based on `<type>` from the conventional commits specification.
  *
  * e.g. 'feat: Add foo'
  *

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -50,6 +50,8 @@ export function formatPath(filePath: string) {
 /**
  * Convert an array of paths to a human-readable sentence listing all the paths.
  *
+ * Joining with commas and an "and".
+ *
  * Leave order as in comes it - though sorting could be added if needed.
  */
 export function humanList(paths: string[]) {

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -46,3 +46,10 @@ export function formatPath(filePath: string) {
   }
   return name;
 }
+
+/**
+ * Convert an array of paths to a human-readable sentence listing all the paths.
+ */
+export function humanList(paths: string[]) {
+  return "foo.txt and bar.txt";
+}

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -10,15 +10,15 @@ import { SplitPathResult } from "./paths.d";
 /**
  * Get metadata for a given path.
  *
- * This is done in one function call to save having to do separate calls or having to the builtin
+ * This is done in one function call to save having to do separate calls or having to the built-in
  * string methods all over the project.
  *
  * Info is derived based on the input value as string, not whether the path to a file that exists or
  * not.
  *
- * Note that path.extname is already smart enough to detect only the last extension if there are
- * multiple dots as see extension as empty string if it is '.filename'. Note that extension has a
- * dot.
+ * Note that `path.extname` is already smart enough to detect only the last extension if there are
+ * multiple dots as see extension as empty string if it is '.filename'. Note that extension will
+ * have a dot.
  */
 export function splitPath(filePath: string): SplitPathResult {
   const dir = path.dirname(filePath),

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -49,6 +49,8 @@ export function formatPath(filePath: string) {
 
 /**
  * Convert an array of paths to a human-readable sentence listing all the paths.
+ *
+ * Leave order as in comes it - though sorting could be added if needed.
  */
 export function humanList(paths: string[]) {
   if (!paths.length) {

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -54,7 +54,7 @@ export function formatPath(filePath: string) {
  */
 export function humanList(paths: string[]) {
   if (!paths.length) {
-    return "";
+    throw new Error("Expected at least one path, got zero");
   }
   if (paths.length === 1) {
     return paths[0];

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -51,5 +51,16 @@ export function formatPath(filePath: string) {
  * Convert an array of paths to a human-readable sentence listing all the paths.
  */
 export function humanList(paths: string[]) {
-  return "foo.txt and bar.txt";
+  if (!paths.length) {
+    return "";
+  }
+  if (paths.length === 1) {
+    return paths[0];
+  }
+  const firstItems = paths.slice(0, paths.length - 1);
+  const lastItem = paths.slice(-1);
+
+  const start = firstItems.join(", ");
+
+  return `${start} and ${lastItem}`;
 }

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -59,9 +59,9 @@ export function humanList(paths: string[]) {
   if (paths.length === 1) {
     return paths[0];
   }
+
   const firstItems = paths.slice(0, paths.length - 1);
   const lastItem = paths.slice(-1);
-
   const start = firstItems.join(", ");
 
   return `${start} and ${lastItem}`;

--- a/src/prepareCommitMsg.ts
+++ b/src/prepareCommitMsg.ts
@@ -25,7 +25,7 @@ function generatePrefixFromChanges(line: string) {
 /**
  * Generate message from changes.
  *
- * Return convention commit prefix and a description of change paths.
+ * Return conventional commit prefix and a description of changed paths.
  */
 export function generateMsgFromChanges(diffIndexLines: string[]) {
   const line = diffIndexLines[0];

--- a/src/prepareCommitMsg.ts
+++ b/src/prepareCommitMsg.ts
@@ -25,10 +25,12 @@ function generatePrefixFromChanges(line: string) {
 /**
  * Generate message from changes.
  *
- * Create semantic convention prefix and description of change paths and return a combined message.
+ * Return convention commit prefix and a description of change paths.
  */
 export function generateMsgFromChanges(diffIndexLines: string[]) {
   const line = diffIndexLines[0];
+
+  // TODO: Should reduceActions go where generatePrefixFromChanges is and which should be used here?
 
   // TODO: Pass FileChanges to one and generatePrefix instead of string.
   // Don't unpack as {x, y, from, to}
@@ -41,7 +43,7 @@ export function generateMsgFromChanges(diffIndexLines: string[]) {
 }
 
 /**
- * Output a readable semantic git commit message.
+ * Output a readable conventional commit message.
  */
 function formatMsg(prefix: CONVENTIONAL_TYPE, fileChangeMsg: string) {
   if (prefix === CONVENTIONAL_TYPE.UNKNOWN) {

--- a/src/test/generate/action.test.ts
+++ b/src/test/generate/action.test.ts
@@ -2,7 +2,7 @@
  * Action test module to check action verbs used.
  */
 import * as assert from "assert";
-import { lookupDiffIndexAction, moveOrRenameFile } from "../../generate/action";
+import { lookupDiffIndexAction, moveOrRenameFile, reduceActions } from "../../generate/action";
 
 describe("Desribe a file using a single path", function () {
   describe("#lookupDiffIndexAction()", function () {
@@ -82,5 +82,13 @@ describe("Desribe a file using two paths", function () {
         "Move and rename foo.txt to bar.txt at repo root"
       );
     });
+  });
+});
+
+describe("Desribe action across multiple files", function () {
+  describe("#actionFromFiles()", function () {
+    assert.strictEqual(reduceActions(
+      ["A", "A", "A"]
+    ), "create");
   });
 });

--- a/src/test/generate/action.test.ts
+++ b/src/test/generate/action.test.ts
@@ -1,3 +1,6 @@
+/**
+ * Action test module to check action verbs used.
+ */
 import * as assert from "assert";
 import { moveOrRenameFile } from "../../generate/action";
 

--- a/src/test/generate/action.test.ts
+++ b/src/test/generate/action.test.ts
@@ -88,9 +88,13 @@ describe("Desribe a file using two paths", function () {
 describe("Desribe action across multiple files", function () {
   describe("#actionFromFiles()", function () {
     it("returns the correct action for identical actions", function () {
-      assert.strictEqual(reduceActions(
-        ["A", "A", "A"]
-      ), "create");
+      assert.strictEqual(reduceActions(["M", "M"]), "update");
+      assert.strictEqual(reduceActions(["A", "A", "A"]), "create");
+    });
+
+    it("returns the null action for different actions", function () {
+      assert.strictEqual(reduceActions(["A", "M"]), "");
+      assert.strictEqual(reduceActions(["A", "M", "A"]), "");
     });
   });
 });

--- a/src/test/generate/action.test.ts
+++ b/src/test/generate/action.test.ts
@@ -87,8 +87,10 @@ describe("Desribe a file using two paths", function () {
 
 describe("Desribe action across multiple files", function () {
   describe("#actionFromFiles()", function () {
-    assert.strictEqual(reduceActions(
-      ["A", "A", "A"]
-    ), "create");
+    it("returns the correct action for identical actions", function () {
+      assert.strictEqual(reduceActions(
+        ["A", "A", "A"]
+      ), "create");
+    });
   });
 });

--- a/src/test/generate/action.test.ts
+++ b/src/test/generate/action.test.ts
@@ -2,9 +2,48 @@
  * Action test module to check action verbs used.
  */
 import * as assert from "assert";
-import { moveOrRenameFile } from "../../generate/action";
+import { lookupDiffIndexAction, moveOrRenameFile } from "../../generate/action";
 
-describe("Desribe a file as moved or renamed", function () {
+describe("Desribe a file using a single path", function () {
+  describe("#lookupDiffIndexAction()", function () {
+    it("can describe an updated file", function () {
+      assert.strictEqual(
+        lookupDiffIndexAction("M"),
+        "update"
+      );
+    });
+
+    it("can describe a created file", function () {
+      assert.strictEqual(
+        lookupDiffIndexAction("A"),
+        "create"
+      );
+    });
+
+    it("can describe a deleted file", function () {
+      assert.strictEqual(
+        lookupDiffIndexAction("D"),
+        "delete"
+      );
+    });
+
+    it("can describe a renamed file", function () {
+      assert.strictEqual(
+        lookupDiffIndexAction("R"),
+        "rename"
+      );
+    });
+
+    it("can describe a copied file", function () {
+      assert.strictEqual(
+        lookupDiffIndexAction("C"),
+        "copy"
+      );
+    });
+  });
+});
+
+describe("Desribe a file using two paths", function () {
   describe("#moveOrRenameFile()", function () {
     it("can describe a renamed file", function () {
       assert.strictEqual(

--- a/src/test/generate/message.test.ts
+++ b/src/test/generate/message.test.ts
@@ -177,8 +177,8 @@ describe("Generate message as verb and filename pairs", function () {
   describe("#actionNamePairs()", function () {
     it("return the appropriate commit message for two files", function () {
       const changes = [
-        { action: ACTION.A, path: "foo.txt" },
-        { action: ACTION.M, path: "bar.txt" },
+        { actionChar: ACTION.A, from: "foo.txt" },
+        { actionChar: ACTION.M, from: "bar.txt" },
       ];
 
       assert.strictEqual(

--- a/src/test/generate/message.test.ts
+++ b/src/test/generate/message.test.ts
@@ -134,7 +134,7 @@ describe("Generate commit message for a single changed file", function () {
 
 describe("Generate commit message for a few changed files which each get named", function () {
   describe("#namedFiles()", function () {
-    it("return the appropriate commit message for a few files", function () {
+    it("return the appropriate commit message for two files with the same action", function () {
       assert.strictEqual(namedFiles(
         ["A    foo.txt", "A    bar.txt"]
       ), "Create foo.txt and bar.txt");
@@ -142,6 +142,10 @@ describe("Generate commit message for a few changed files which each get named",
       assert.strictEqual(namedFiles(
         ["M    foo.txt", "M    bar.txt"]
       ), "Update foo.txt and bar.txt");
+
+      assert.strictEqual(namedFiles(
+        ["M    fizz.js", "M    buzz.ts"]
+      ), "Update fizz.js and buzz.ts");
     });
 
     it("handles differing actions", function () {

--- a/src/test/generate/message.test.ts
+++ b/src/test/generate/message.test.ts
@@ -134,7 +134,7 @@ describe("Generate commit message for a single changed file", function () {
 
 describe("Generate commit message for a few changed files which each get named", function () {
   describe("#namedFiles()", function () {
-    it("return the appropriate commit message for two files with the same action", function () {
+    it("return the appropriate commit message for two files", function () {
       assert.strictEqual(namedFiles(
         ["A    foo.txt", "A    bar.txt"]
       ), "Create foo.txt and bar.txt");
@@ -146,6 +146,16 @@ describe("Generate commit message for a few changed files which each get named",
       assert.strictEqual(namedFiles(
         ["M    fizz.js", "M    buzz.ts"]
       ), "Update fizz.js and buzz.ts");
+    });
+
+    it("return a commit message for more than two files", function () {
+      assert.strictEqual(namedFiles(
+        ["A    foo.txt", "A    docs/bar.txt", "A    buzz.js"]
+      ), "Create foo.txt, docs/bar.txt and buzz.js");
+
+      assert.strictEqual(namedFiles(
+        ["D    foo.txt", "D    docs/bar.txt", "D    buzz.js"]
+      ), "Delete foo.txt, docs/bar.txt and buzz.js");
     });
 
     it("handles differing actions", function () {

--- a/src/test/generate/message.test.ts
+++ b/src/test/generate/message.test.ts
@@ -1,5 +1,7 @@
 /**
- * High-level test of message is shown to the user, based on changes to one or more files.
+ * Message test module.
+ *
+ * High-level test of the message shown to the user, based on changes to one or more files.
  */
 import * as assert from "assert";
 import { oneChange } from "../../generate/message";

--- a/src/test/generate/message.test.ts
+++ b/src/test/generate/message.test.ts
@@ -5,7 +5,8 @@
  * includes the action verb in a sentence along with named files, but not the semantic convention.
  */
 import * as assert from "assert";
-import { namedFiles, oneChange } from "../../generate/message";
+import { actionNamePairs, namedFiles, oneChange } from "../../generate/message";
+import { ACTION } from "../../lib/constants";
 
 describe("Generate commit message for a single changed file", function () {
   // Note that git status --short expects XY format but this is for git diff-index
@@ -166,6 +167,24 @@ describe("Generate commit message for a few changed files which each get named",
       assert.strictEqual(namedFiles(
         ["M    foo.txt", "D    bar.txt"]
       ), "Various changes to foo.txt and bar.txt");
+    });
+  });
+});
+
+// TODO - move spliting of "A  foo.txt" into a high-level function and low level ones deal with
+// objects to keep things simple and type safe.
+describe("Generate message as verb and filename pairs", function () {
+  describe("#actionNamePairs()", function () {
+    it("return the appropriate commit message for two files", function () {
+      const changes = [
+        { action: ACTION.A, path: "foo.txt" },
+        { action: ACTION.M, path: "bar.txt" },
+      ];
+
+      assert.strictEqual(
+        actionNamePairs(changes),
+        "Create foo.txt and update bar.txt"
+      );
     });
   });
 });

--- a/src/test/generate/message.test.ts
+++ b/src/test/generate/message.test.ts
@@ -138,6 +138,10 @@ describe("Generate commit message for a few changed files which each get named",
       assert.strictEqual(namedFiles(
         ["A    foo.txt", "A    bar.txt"]
       ), "Create foo.txt and bar.txt");
+
+      assert.strictEqual(namedFiles(
+        ["M    foo.txt", "M    bar.txt"]
+      ), "Update foo.txt and bar.txt");
     });
   });
 });

--- a/src/test/generate/message.test.ts
+++ b/src/test/generate/message.test.ts
@@ -1,10 +1,11 @@
 /**
  * Message test module.
  *
- * High-level test of the message shown to the user, based on changes to one or more files.
+ * High-level test of the message shown to the user, based on changes to one or more files. This
+ * includes the action verb in a sentence along with named files, but not the semantic convention.
  */
 import * as assert from "assert";
-import { oneChange } from "../../generate/message";
+import { namedFiles, oneChange } from "../../generate/message";
 
 describe("Generate commit message for a single changed file", function () {
   // Note that git status --short expects XY format but this is for git diff-index
@@ -128,5 +129,17 @@ describe("Generate commit message for a single changed file", function () {
       assert.strictEqual(oneChange("A    foo/index.md"), "Create foo/index.md");
       assert.strictEqual(oneChange("A    foo/index.js"), "Create foo/index.js");
     });
+  });
+});
+
+
+describe("Generate commit message for a few changed files which each get named", function () {
+  describe("#namedFiles()", function () {
+    it("return the appropriate commit message for a few files", function () {
+      assert.strictEqual(namedFiles(
+        ["A    foo.txt", "A    bar.txt"]
+      ), "Create foo.txt and bar.txt");
+    });
+
   });
 });

--- a/src/test/generate/message.test.ts
+++ b/src/test/generate/message.test.ts
@@ -132,7 +132,6 @@ describe("Generate commit message for a single changed file", function () {
   });
 });
 
-
 describe("Generate commit message for a few changed files which each get named", function () {
   describe("#namedFiles()", function () {
     it("return the appropriate commit message for a few files", function () {
@@ -140,6 +139,5 @@ describe("Generate commit message for a few changed files which each get named",
         ["A    foo.txt", "A    bar.txt"]
       ), "Create foo.txt and bar.txt");
     });
-
   });
 });

--- a/src/test/generate/message.test.ts
+++ b/src/test/generate/message.test.ts
@@ -143,5 +143,15 @@ describe("Generate commit message for a few changed files which each get named",
         ["M    foo.txt", "M    bar.txt"]
       ), "Update foo.txt and bar.txt");
     });
+
+    it("handles differing actions", function () {
+      assert.strictEqual(namedFiles(
+        ["A    foo.txt", "M    bar.txt"]
+      ), "Various changes to foo.txt and bar.txt");
+
+      assert.strictEqual(namedFiles(
+        ["M    foo.txt", "D    bar.txt"]
+      ), "Various changes to foo.txt and bar.txt");
+    });
   });
 });

--- a/src/test/generate/semantic.test.ts
+++ b/src/test/generate/semantic.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Semantic test module.
+ *
+ * Check the categorization of changed files into semantic convention commit types.
+ */
 import * as assert from "assert";
 import { getSemanticConvention, Semantic } from "../../generate/semantic";
 import { ACTION, CONVENTIONAL_TYPE } from "../../lib/constants";

--- a/src/test/generate/semantic.test.ts
+++ b/src/test/generate/semantic.test.ts
@@ -1,7 +1,7 @@
 /**
  * Semantic test module.
  *
- * Check the categorization of changed files into semantic convention commit types.
+ * Check the categorization of changed files into semantic (aka conventional commit) types.
  */
 import * as assert from "assert";
 import { getSemanticConvention, Semantic } from "../../generate/semantic";

--- a/src/test/git/parseOutput.test.ts
+++ b/src/test/git/parseOutput.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Parse output test module.
+ *
+ * Check the ability to convert text output from git commands into JS objects.
+ */
 import * as assert from "assert";
 import { parseDiffIndex, parseStatus } from "../../git/parseOutput";
 import { FileChanges } from "../../git/parseOutput.d";

--- a/src/test/lib/commonPath.test.ts
+++ b/src/test/lib/commonPath.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Common path test module.
+ *
+ * Check that a common path can be found for paths.
+ */
 import * as assert from "assert";
 import { commonPath } from "../../lib/commonPath";
 

--- a/src/test/lib/paths.test.ts
+++ b/src/test/lib/paths.test.ts
@@ -69,6 +69,12 @@ describe("Path handling", function () {
       ), "foo.txt, bar.txt, bazz.js and buzz.ts");
     });
 
+    it("returns a sentence for four longer paths", function () {
+      assert.strictEqual(humanList(
+        ["foo.txt", "docs/bar.txt", "src/lib/bazz.js", "src/buzz.ts"]
+      ), "foo.txt, docs/bar.txt, src/lib/bazz.js and src/buzz.ts");
+    });
+
     it("throws an error for zero files", function () {
       assert.throws(() => humanList([]));
     });

--- a/src/test/lib/paths.test.ts
+++ b/src/test/lib/paths.test.ts
@@ -4,7 +4,7 @@
  * Check handling of paths as text.
  */
 import * as assert from "assert";
-import { formatPath, splitPath } from "../../lib/paths";
+import { formatPath, humanList, splitPath } from "../../lib/paths";
 
 describe("Path handling", function () {
   describe("#splitPath()", function () {
@@ -41,6 +41,14 @@ describe("Path handling", function () {
       assert.strictEqual(formatPath("Foo/index.md"), "Foo/index.md");
       assert.strictEqual(formatPath("Foo/index.html"), "Foo/index.html");
       assert.strictEqual(formatPath("Foo/index.js"), "Foo/index.js");
+    });
+  });
+
+  describe("#humanList()", function () {
+    it("returns a sentence for two files", function () {
+      assert.strictEqual(humanList(
+        ["foo.txt", "bar.txt"]
+      ), "foo.txt and bar.txt");
     });
   });
 });

--- a/src/test/lib/paths.test.ts
+++ b/src/test/lib/paths.test.ts
@@ -68,5 +68,9 @@ describe("Path handling", function () {
         ["foo.txt", "bar.txt", "bazz.js", "buzz.ts"]
       ), "foo.txt, bar.txt, bazz.js and buzz.ts");
     });
+
+    it("throws an error for zero files", function () {
+      assert.throws(() => humanList([]));
+    });
   });
 });

--- a/src/test/lib/paths.test.ts
+++ b/src/test/lib/paths.test.ts
@@ -45,6 +45,12 @@ describe("Path handling", function () {
   });
 
   describe("#humanList()", function () {
+    it("returns a path for a single file", function () {
+      assert.strictEqual(humanList(
+        ["foo.txt"]
+      ), "foo.txt");
+    });
+
     it("returns a sentence for two files", function () {
       assert.strictEqual(humanList(
         ["foo.txt", "bar.txt"]

--- a/src/test/lib/paths.test.ts
+++ b/src/test/lib/paths.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Paths test module.
+ *
+ * Check handling of paths as text.
+ */
 import * as assert from "assert";
 import { formatPath, splitPath } from "../../lib/paths";
 

--- a/src/test/lib/paths.test.ts
+++ b/src/test/lib/paths.test.ts
@@ -50,5 +50,17 @@ describe("Path handling", function () {
         ["foo.txt", "bar.txt"]
       ), "foo.txt and bar.txt");
     });
+
+    it("returns a sentence for three files", function () {
+      assert.strictEqual(humanList(
+        ["foo.txt", "bar.txt", "bazz.js"]
+      ), "foo.txt, bar.txt and bazz.js");
+    });
+
+    it("returns a sentence for four files", function () {
+      assert.strictEqual(humanList(
+        ["foo.txt", "bar.txt", "bazz.js", "buzz.ts"]
+      ), "foo.txt, bar.txt, bazz.js and buzz.ts");
+    });
   });
 });

--- a/src/test/prepareCommitMsg.test.ts
+++ b/src/test/prepareCommitMsg.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Prepare commit message test module.
+ *
+ * Check creation of commit message.
+ */
+import * as assert from "assert";
+import { generateMsgFromChanges } from "../prepareCommitMsg";
+
+describe("Prepare commit message", function () {
+  describe("#generateMsgFromChanges()", function () {
+    it("splits a path correctly", function () {
+      const expected = {
+        prefix: "feat",
+        fileChangeMsg: "Create baz.txt",
+      };
+
+      assert.deepStrictEqual(
+        generateMsgFromChanges(["A    baz.txt"]), expected);
+    });
+  });
+});


### PR DESCRIPTION
Handle different action verbs for each file e.g. `Create foo.txt and delete fizz.js`

This turned out to be hard to implement because of existing structure.

A refactor and paper design would be useful before implementing this to keep it clean.

I was able to add stuff that is merged that handles multiple changes, so this PR is not needed as much but might have some useful stuff.

This WIP branch can be used for help but can be thrown away.

Relates to #29 