### PR TITLE
feat: use commit message template value as prefix

### DIFF
--- a/bin/reset_sandbox.sh
+++ b/bin/reset_sandbox.sh
@@ -31,3 +31,7 @@ mkdir -p my_subdir
 mv bazz.js my_subdir
 # Delete.
 rm buzz.js
+
+# Commit template.
+git config commit.template _COMMIT_MESSAGE
+echo 'My commit prefix' >_COMMIT_MESSAGE

--- a/src/autofill.ts
+++ b/src/autofill.ts
@@ -22,7 +22,11 @@ Try saving your files or stage any new (untracked) files.\
  *   2. Generate a message.
  *   3. Push message value to the commit message box.
  *
- * This is based on `prefixCommit` from the `git-prefix` extension.
+ * New functionality in the extension - the commit message file is read
+ * explicitly and the content used. Any content in the Git pane that was the
+ * "old message" is ignored then.
+ *
+ * This function is based on `prefixCommit` from the `git-prefix` extension.
  */
 export async function makeAndFillCommitMsg(repository: Repository) {
   const fileChanges = await getChanges();

--- a/src/autofill.ts
+++ b/src/autofill.ts
@@ -4,6 +4,7 @@
 import * as vscode from "vscode";
 import { Repository } from "./api/git";
 import { getChanges } from "./git/cli";
+import { getCommitTemplateValue } from "./git/commitTemplate";
 import { getCommitMsg, setCommitMsg } from "./gitExtension";
 import { generateMsg } from "./prepareCommitMsg";
 
@@ -38,6 +39,9 @@ export async function makeAndFillCommitMsg(repository: Repository) {
 
   const newMsg = generateMsg(fileChanges, oldMsg);
   console.debug("New message: ", newMsg);
+
+  const commitMessageValue = await getCommitTemplateValue()
+  console.debug({ commitMessageValue })
 
   setCommitMsg(repository, newMsg);
 }

--- a/src/autofill.ts
+++ b/src/autofill.ts
@@ -40,8 +40,8 @@ export async function makeAndFillCommitMsg(repository: Repository) {
   const newMsg = generateMsg(fileChanges, oldMsg);
   console.debug("New message: ", newMsg);
 
-  const commitMessageValue = await getCommitTemplateValue()
-  console.debug({ commitMessageValue })
+  const commitMessageValue = await getCommitTemplateValue();
+  console.debug({ commitMessageValue });
 
   setCommitMsg(repository, newMsg);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,11 @@ import { generateMsg } from "./prepareCommitMsg";
  *
  * Expect multi-line text from `git diff-index` command as the first item in the shell arguments.
  *
+ * TODO: How to reverse the order so reading the value and using it as old message can appear _first_.
+ * Note that, unlike the VS Code extension, the CLI logic here cannot read an
+ * "old message" from the Git pane so that is not passed to `generateMsg`.
+ * Though maybe this can be modified using `commitTemplate.ts`.
+ *
  * Returns a suitable generated commit message as text.
  */
 function main(args: string[]) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,32 +57,7 @@ async function _handleRepos(git: API, sourceControl: any) {
  */
 async function _handleRepo(git: API) {
   const targetRepo = git.repositories[0];
-
   await makeAndFillCommitMsg(targetRepo);
-}
-
-async function _autofill(uri?: string) {
-  const git = getGitExtension();
-
-  if (!git) {
-    vscode.window.showErrorMessage("Unable to load Git Extension");
-    return;
-  }
-
-  if (git.repositories.length === 0) {
-    vscode.window.showErrorMessage(
-      "No repos found. Please open a repo or run git init then try this extension again."
-    );
-    return;
-  }
-
-  vscode.commands.executeCommand("workbench.view.scm");
-
-  if (uri) {
-    _handleRepos(git, uri);
-  } else {
-    _handleRepo(git);
-  }
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,6 @@
 import * as vscode from "vscode";
 import { API } from "./api/git";
 import { makeAndFillCommitMsg } from "./autofill";
-import { getCommitTemplateName } from "./git/cli";
 import { getGitExtension } from "./gitExtension";
 
 function _validateFoundRepos(git: API) {
@@ -84,10 +83,6 @@ async function _autofill(uri?: string) {
   } else {
     _handleRepo(git);
   }
-
-  const templateName = await getCommitTemplateName()
-  console.debug(templateName)
-
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@
 import * as vscode from "vscode";
 import { API } from "./api/git";
 import { makeAndFillCommitMsg } from "./autofill";
+import { getCommitTemplateName } from "./git/cli";
 import { getGitExtension } from "./gitExtension";
 
 function _validateFoundRepos(git: API) {
@@ -57,7 +58,36 @@ async function _handleRepos(git: API, sourceControl: any) {
  */
 async function _handleRepo(git: API) {
   const targetRepo = git.repositories[0];
+
   await makeAndFillCommitMsg(targetRepo);
+}
+
+async function _autofill(uri?: string) {
+  const git = getGitExtension();
+
+  if (!git) {
+    vscode.window.showErrorMessage("Unable to load Git Extension");
+    return;
+  }
+
+  if (git.repositories.length === 0) {
+    vscode.window.showErrorMessage(
+      "No repos found. Please open a repo or run git init then try this extension again."
+    );
+    return;
+  }
+
+  vscode.commands.executeCommand("workbench.view.scm");
+
+  if (uri) {
+    _handleRepos(git, uri);
+  } else {
+    _handleRepo(git);
+  }
+
+  const templateName = await getCommitTemplateName()
+  console.debug(templateName)
+
 }
 
 /**

--- a/src/git/cli.ts
+++ b/src/git/cli.ts
@@ -13,7 +13,11 @@ const exec = util.promisify(childProcess.exec);
 /**
  * Run a `git` subcommand with options and return output.
  */
-export function execute(cwd: string, subcommand: string, options: string[] = []) {
+export function execute(
+  cwd: string,
+  subcommand: string,
+  options: string[] = []
+) {
   const command = `git ${subcommand} ${options.join(" ")}`;
 
   const result = exec(command, { cwd });
@@ -45,12 +49,8 @@ async function _diffIndex(options: string[] = []): Promise<Array<string>> {
     "HEAD",
   ];
 
-  const workspace = getWorkspaceFolder()
-  const { stdout, stderr } = await execute(
-    workspace,
-    cmd,
-    fullOptions
-  );
+  const workspace = getWorkspaceFolder();
+  const { stdout, stderr } = await execute(workspace, cmd, fullOptions);
 
   if (stderr) {
     console.debug(`stderr for 'git ${cmd}' command:`, stderr);

--- a/src/git/cli.ts
+++ b/src/git/cli.ts
@@ -13,7 +13,7 @@ const exec = util.promisify(childProcess.exec);
 /**
  * Run a `git` subcommand with options and return output.
  */
-function _execute(cwd: string, subcommand: string, options: string[] = []) {
+export function execute(cwd: string, subcommand: string, options: string[] = []) {
   const command = `git ${subcommand} ${options.join(" ")}`;
 
   const result = exec(command, { cwd });
@@ -44,8 +44,10 @@ async function _diffIndex(options: string[] = []): Promise<Array<string>> {
     ...options,
     "HEAD",
   ];
-  const { stdout, stderr } = await _execute(
-    getWorkspaceFolder(),
+
+  const workspace = getWorkspaceFolder()
+  const { stdout, stderr } = await execute(
+    workspace,
     cmd,
     fullOptions
   );
@@ -87,37 +89,4 @@ export async function getChanges() {
     console.debug("No changes found");
   }
   return allChanges;
-}
-
-
-/**
- * Get a value from the Git config.
- *
- * The CLI will assume local (project) project by default.
- */
-export async function _getConfigValue(options: string[]) {
-  const cmd = "config"
-
-  const { stdout, stderr } = await _execute(
-    getWorkspaceFolder(),
-    cmd,
-    options
-  );
-
-  if (stderr) {
-    console.debug(`stderr for 'git ${cmd}' command:`, stderr);
-  }
-
-  return stdout
-}
-
-/**
- * Get the configured value for a commit template path if set, or empty string.
- */
-export async function getCommitTemplateName() {
-  try {
-    return await _getConfigValue(['commit.template'])
-  } catch (_e) {
-    return ""
-  }
 }

--- a/src/git/cli.ts
+++ b/src/git/cli.ts
@@ -88,3 +88,36 @@ export async function getChanges() {
   }
   return allChanges;
 }
+
+
+/**
+ * Get a value from the Git config.
+ *
+ * The CLI will assume local (project) project by default.
+ */
+export async function _getConfigValue(options: string[]) {
+  const cmd = "config"
+
+  const { stdout, stderr } = await _execute(
+    getWorkspaceFolder(),
+    cmd,
+    options
+  );
+
+  if (stderr) {
+    console.debug(`stderr for 'git ${cmd}' command:`, stderr);
+  }
+
+  return stdout
+}
+
+/**
+ * Get the configured value for a commit template path if set, or empty string.
+ */
+export async function getCommitTemplateName() {
+  try {
+    return await _getConfigValue(['commit.template'])
+  } catch (_e) {
+    return ""
+  }
+}

--- a/src/git/commitTemplate.ts
+++ b/src/git/commitTemplate.ts
@@ -11,13 +11,13 @@
  *
  * To avoid making an extra config value for the extension that one has to manage say in a Settings file or internal data, the approach is rather to use the existing commit template pattern in Git.
  */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from "fs";
+import * as path from "path";
 import { getWorkspaceFolder } from "../workspace";
 import { execute } from "./cli";
 
-const CONFIG_SUBCOMMAND = "config"
-const COMMIT_TEMPLATE_IDENTIFIER = 'commit.template'
+const CONFIG_SUBCOMMAND = "config";
+const COMMIT_TEMPLATE_IDENTIFIER = "commit.template";
 
 /**
  * Get a value from the Git config.
@@ -25,7 +25,7 @@ const COMMIT_TEMPLATE_IDENTIFIER = 'commit.template'
  * The CLI will assume local (project) project by default.
  */
 export async function _getConfigValue(options: string[]) {
-  const workspace = getWorkspaceFolder()
+  const workspace = getWorkspaceFolder();
   const { stdout, stderr } = await execute(
     workspace,
     CONFIG_SUBCOMMAND,
@@ -36,7 +36,7 @@ export async function _getConfigValue(options: string[]) {
     console.debug(`stderr for 'git ${CONFIG_SUBCOMMAND}' command:`, stderr);
   }
 
-  return stdout
+  return stdout;
 }
 
 /**
@@ -46,10 +46,10 @@ export async function _getConfigValue(options: string[]) {
  */
 async function _getCommitTemplatePath() {
   try {
-    const options = [COMMIT_TEMPLATE_IDENTIFIER]
-    return await _getConfigValue(options)
+    const options = [COMMIT_TEMPLATE_IDENTIFIER];
+    return await _getConfigValue(options);
   } catch (_e) {
-    return null
+    return null;
   }
 }
 
@@ -59,26 +59,26 @@ async function _getCommitTemplatePath() {
  * NB. Use current workspace as the base path.
  */
 function _readFile(filePath: string) {
-  const workspace = getWorkspaceFolder()
-  const p = path.join(workspace, filePath)
+  const workspace = getWorkspaceFolder();
+  const p = path.join(workspace, filePath);
 
-  let value
+  let value;
 
   try {
-    value = fs.readFileSync(p, "utf-8")
+    value = fs.readFileSync(p, "utf-8");
   } catch (err) {
-    console.error(`Could not find template file: ${p}. ${err.toString()}`)
+    console.error(`Could not find template file: ${p}. ${err.toString()}`);
 
-    return null
+    return null;
   }
 
   if (!value) {
-    return null
+    return null;
   }
 
-  console.debug(`Read ${p} and found: ${value}`)
+  console.debug(`Read ${p} and found: ${value}`);
 
-  return value
+  return value;
 }
 
 /**
@@ -87,12 +87,12 @@ function _readFile(filePath: string) {
  * Return null if file is not configured or file is missing, without aborting.
  */
 export async function getCommitTemplateValue() {
-  const filePath = await _getCommitTemplatePath()
+  const filePath = await _getCommitTemplatePath();
 
   if (!filePath) {
-    console.error(`Could not read missing file: ${filePath}`)
-    return null
+    console.error(`Could not read missing file: ${filePath}`);
+    return null;
   }
 
-  return _readFile(filePath)
+  return _readFile(filePath);
 }

--- a/src/git/commitTemplate.ts
+++ b/src/git/commitTemplate.ts
@@ -31,11 +31,10 @@ const COMMIT_TEMPLATE_IDENTIFIER = "commit.template";
 
 /**
  * Get a value from the Git config.
- *
- * The CLI will assume local (project) project by default.
  */
 export async function _getConfigValue(options: string[]) {
   const workspace = getWorkspaceFolder();
+
   const { stdout, stderr } = await execute(
     workspace,
     CONFIG_SUBCOMMAND,
@@ -101,6 +100,7 @@ export async function getCommitTemplateValue() {
 
   if (!filePath) {
     console.error(`Could not read missing file: ${filePath}`);
+
     return null;
   }
 

--- a/src/git/commitTemplate.ts
+++ b/src/git/commitTemplate.ts
@@ -30,7 +30,7 @@ const CONFIG_SUBCOMMAND = "config";
 const COMMIT_TEMPLATE_IDENTIFIER = "commit.template";
 
 /**
- * Get a value from the Git config.
+ * Get a value from the local Git config.
  */
 export async function _getConfigValue(options: string[]) {
   const workspace = getWorkspaceFolder();
@@ -56,8 +56,11 @@ export async function _getConfigValue(options: string[]) {
 async function _getCommitTemplatePath() {
   try {
     const options = [COMMIT_TEMPLATE_IDENTIFIER];
+
     return await _getConfigValue(options);
   } catch (_e) {
+    console.error(_e)
+
     return null;
   }
 }

--- a/src/git/commitTemplate.ts
+++ b/src/git/commitTemplate.ts
@@ -1,0 +1,98 @@
+/**
+ * Commit template module.
+ *
+ * TODO: Move to docs and link there.
+ *
+ * Read the message from the a configured commit template file and use it as a prefix in the message.
+ *
+ * A commit template is built-in Git behavior to see a value for the start of each commit message. This is useful if you have a ticket number, project name, or similar to add at the start of each commit.
+ *
+ * Note that VS Code and Git CLI both automatically read from this file when generating a commit. However, the value is hard to use. There is behavior in this extension to move the old message to the end and enter a commit type prefix and commit message before it, but there is no way to know from the content of the message for sure whether the old message is a commit template value or just a hand-typed message.
+ *
+ * To avoid making an extra config value for the extension that one has to manage say in a Settings file or internal data, the approach is rather to use the existing commit template pattern in Git.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { getWorkspaceFolder } from "../workspace";
+import { execute } from "./cli";
+
+const CONFIG_SUBCOMMAND = "config"
+const COMMIT_TEMPLATE_IDENTIFIER = 'commit.template'
+
+/**
+ * Get a value from the Git config.
+ *
+ * The CLI will assume local (project) project by default.
+ */
+export async function _getConfigValue(options: string[]) {
+  const workspace = getWorkspaceFolder()
+  const { stdout, stderr } = await execute(
+    workspace,
+    CONFIG_SUBCOMMAND,
+    options
+  );
+
+  if (stderr) {
+    console.debug(`stderr for 'git ${CONFIG_SUBCOMMAND}' command:`, stderr);
+  }
+
+  return stdout
+}
+
+/**
+ * Get commit template path.
+ *
+ * Get the configured value for a commit template path if set.
+ */
+async function _getCommitTemplatePath() {
+  try {
+    const options = [COMMIT_TEMPLATE_IDENTIFIER]
+    return await _getConfigValue(options)
+  } catch (_e) {
+    return null
+  }
+}
+
+/**
+ * Read a file.
+ *
+ * NB. Use current workspace as the base path.
+ */
+function _readFile(filePath: string) {
+  const workspace = getWorkspaceFolder()
+  const p = path.join(workspace, filePath)
+
+  let value
+
+  try {
+    value = fs.readFileSync(p, "utf-8")
+  } catch (err) {
+    console.error(`Could not find template file: ${p}. ${err.toString()}`)
+
+    return null
+  }
+
+  if (!value) {
+    return null
+  }
+
+  console.debug(`Read ${p} and found: ${value}`)
+
+  return value
+}
+
+/**
+ * Get value of commit template file.
+ *
+ * Return null if file is not configured or file is missing, without aborting.
+ */
+export async function getCommitTemplateValue() {
+  const filePath = await _getCommitTemplatePath()
+
+  if (!filePath) {
+    console.error(`Could not read missing file: ${filePath}`)
+    return null
+  }
+
+  return _readFile(filePath)
+}

--- a/src/git/commitTemplate.ts
+++ b/src/git/commitTemplate.ts
@@ -76,7 +76,7 @@ function _readFile(filePath: string) {
 
   try {
     value = fs.readFileSync(p, "utf-8");
-  } catch (err) {
+  } catch (err: any) {
     console.error(`Could not find template file: ${p}. ${err.toString()}`);
 
     return null;

--- a/src/git/commitTemplate.ts
+++ b/src/git/commitTemplate.ts
@@ -3,13 +3,23 @@
  *
  * TODO: Move to docs and link there.
  *
- * Read the message from the a configured commit template file and use it as a prefix in the message.
+ * Read the message from the a configured commit template file and use it as a
+ * prefix in the message.
  *
- * A commit template is built-in Git behavior to see a value for the start of each commit message. This is useful if you have a ticket number, project name, or similar to add at the start of each commit.
+ * A commit template is built-in Git behavior to see a value for the start of
+ * each commit message. This is useful if you have a ticket number, project
+ * name, or similar to add at the start of each commit.
  *
- * Note that VS Code and Git CLI both automatically read from this file when generating a commit. However, the value is hard to use. There is behavior in this extension to move the old message to the end and enter a commit type prefix and commit message before it, but there is no way to know from the content of the message for sure whether the old message is a commit template value or just a hand-typed message.
+ * Note that VS Code and Git CLI both automatically read from this file when
+ * generating a commit. However, the value is hard to use. There is behavior in
+ * this extension to move the old message to the end and enter a commit type
+ * prefix and commit message before it, but there is no way to know from the
+ * content of the message for sure whether the old message is a commit template
+ * value or just a hand-typed message.
  *
- * To avoid making an extra config value for the extension that one has to manage say in a Settings file or internal data, the approach is rather to use the existing commit template pattern in Git.
+ * To avoid making an extra config value for the extension that one has to
+ * manage say in a Settings file or internal data, the approach is rather to use
+ * the existing commit template pattern in Git.
  */
 import * as fs from "fs";
 import * as path from "path";

--- a/src/git/commitTemplate.ts
+++ b/src/git/commitTemplate.ts
@@ -59,7 +59,7 @@ async function _getCommitTemplatePath() {
 
     return await _getConfigValue(options);
   } catch (_e) {
-    console.error(_e)
+    console.error(_e);
 
     return null;
   }

--- a/src/git/commitTemplate.ts
+++ b/src/git/commitTemplate.ts
@@ -65,7 +65,7 @@ async function _getCommitTemplatePath() {
 /**
  * Read a file.
  *
- * @param filePath: Path to a file to read, relative to the workspace root.
+ * @param filePath Path to a file to read, relative to the workspace root.
  *   e.g. "abc.txt" or "abc/def.txt"
  */
 function _readFile(filePath: string) {
@@ -94,7 +94,8 @@ function _readFile(filePath: string) {
 /**
  * Get value of commit template file.
  *
- * Return null if file is not configured or file is missing, without aborting.
+ * @return Contents of a configured commit message template file, or `null` if
+ *   file is not configured or file is missing.
  */
 export async function getCommitTemplateValue() {
   const filePath = await _getCommitTemplatePath();

--- a/src/git/commitTemplate.ts
+++ b/src/git/commitTemplate.ts
@@ -65,7 +65,8 @@ async function _getCommitTemplatePath() {
 /**
  * Read a file.
  *
- * NB. Use current workspace as the base path.
+ * @param filePath: Path to a file to read, relative to the workspace root.
+ *   e.g. "abc.txt" or "abc/def.txt"
  */
 function _readFile(filePath: string) {
   const workspace = getWorkspaceFolder();
@@ -85,7 +86,7 @@ function _readFile(filePath: string) {
     return null;
   }
 
-  console.debug(`Read ${p} and found: ${value}`);
+  console.debug(`Found file: ${p}. Found contents: ${value}`);
 
   return value;
 }

--- a/src/prepareCommitMsg.ts
+++ b/src/prepareCommitMsg.ts
@@ -218,7 +218,7 @@ export function _generateMsgWithOld(lines: string[], oldMsg: string) {
  *
  * Old message could be the current commit message value in the UI box (which might be a commit
  * message template that VS Code has filled in), or a commit message template read from a file in
- * the case of a hook flow without VS Code.
+ * the case of a hook flow without VS Code (built-in Git functionality).
  *
  * @param lines A list of text values describing how files changes.
  */


### PR DESCRIPTION
resolves #63 

Progress:

- [x] Read config value
- [x] Read file
- [ ] Functionality and tests to use a given prefix in a commit message
- [ ] Functionality and tests to tie the config file and commit message together. TBD how to mock the existence of config value
- [ ] Integration tests for reading config and file in the sample repo? Even if using mocks for file contents
- [ ] Documentation updates