### PR TITLE
feat: add on-save logic

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@
  * the prepareCommitMsg module to a target branch.
  */
 import * as vscode from "vscode";
+import { TextDocument } from "vscode";
 import { API } from "./api/git";
 import { makeAndFillCommitMsg } from "./autofill";
 import { getGitExtension } from "./gitExtension";
@@ -89,6 +90,15 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(disposable);
+  context.subscriptions.push(
+    vscode.workspace.onDidSaveTextDocument((e: TextDocument) => {
+      vscode.window.showInformationMessage(
+        `Generating commit message because file was saved - ${e.fileName}`
+      );
+      // TODO: Handle multiple repos by passing `sourceControl` or `uri`.
+      _chooseRepoForAutofill();
+    })
+  );
 }
 
 // prettier-ignore


### PR DESCRIPTION
Resolves #65.

TODO: 

- [ ] Make this configurable and default off.
- [ ] Prevent auto-focus on Git pane from other panes.
- [ ] Maybe ignore save on files outside the repo.
- [ ] Multi-repo support.
- [ ] On save when there are no changes and esp outside the repo - avoid error message that there is nothing to generate from.
- [ ] Figure out what to do where there is _already_ a message filled and one saves. Then `chore: pull in changes from main in extension.ts` becomes `chore: update extension.ts pull in changes from main in extension.ts` which is bad. At least for the save approach - two flows then?