### PR TITLE
fix: Git root URI should not be absolute for Windows

### DIFF
--- a/docs/development/advanced/debugging.md
+++ b/docs/development/advanced/debugging.md
@@ -13,7 +13,7 @@ This snippet of code can be used to for testing that a basic command works witho
 async function _test(repository: Repository) {
   vscode.window.showInformationMessage("Testing")
 
-  let cwd = repository.rootUri.path;
+  let cwd = repository.rootUri.fsPath;
 
   vscode.window.showInformationMessage(cwd)
 
@@ -28,10 +28,4 @@ This was prompted by issue [#93](https://github.com/MichaelCurrin/auto-commit-ms
 
 The output in the debug mode did not work because the shell command failed to spawn at all using `exec()` in Node. 
 
-I printed the `cwd` value in the VS Code info box using code above. I realized that when it was used with `git` in `cmd` on Windows that the path was not valid. Showing as `/c:/...` with a leading forward-slash appropriate for Linux/macOS but not Windows `cmd`.
-
-This is the temporary hack until the `vscode` library has a fix:
-
-```typescript
-cwd = cwd.replace("/c:/", "c:/")
-```
+The `cwd` value was incorrect from the existing logs which I didn't notice initially but using the test above made it clear. 

--- a/docs/development/advanced/debugging.md
+++ b/docs/development/advanced/debugging.md
@@ -1,0 +1,37 @@
+# Debugging
+> How to deal with errors in the extension
+
+## Test shell commands
+
+This snippet of code can be used to for testing that a basic command works without error and output can be shown.
+
+```typescript
+/**
+ * Debug tool for checking that a basic command works.
+ * Replace the `makeAndFillCommitMsg` call with `test` to use this.
+ */
+async function _test(repository: Repository) {
+  vscode.window.showInformationMessage("Testing")
+
+  let cwd = repository.rootUri.path;
+
+  vscode.window.showInformationMessage(cwd)
+
+  const resp = await _execute(cwd, 'git --version')
+  vscode.window.showInformationMessage(`${resp.stdout} -- ${resp.stderr}`)
+}
+```
+
+### Background
+
+This was prompted by issue [#93](https://github.com/MichaelCurrin/auto-commit-msg/issues/93) on Windows.
+
+The output in the debug mode did not work because the shell command failed to spawn at all using `exec()` in Node. 
+
+I printed the `cwd` value in the VS Code info box using code above. I realized that when it was used with `git` in `cmd` on Windows that the path was not valid. Showing as `/c:/...` with a leading forward-slash appropriate for Linux/macOS but not Windows `cmd`.
+
+This is the temporary hack until the `vscode` library has a fix:
+
+```typescript
+cwd = cwd.replace("/c:/", "c:/")
+```

--- a/src/git/cli.ts
+++ b/src/git/cli.ts
@@ -36,10 +36,7 @@ async function _diffIndex(
   repository: Repository,
   options: string[] = []
 ): Promise<Array<string>> {
-  let cwd = repository.rootUri.path;
-  // Hack to make handle Windows path from rootUri, since it should not appear as a root path.
-  cwd = cwd.replace("/c:/", "c:/");
-
+  let cwd = repository.rootUri.fspath;
   const cmd = "diff-index";
   const fullOptions = [
     "--name-status",

--- a/src/git/cli.ts
+++ b/src/git/cli.ts
@@ -36,7 +36,7 @@ async function _diffIndex(
   repository: Repository,
   options: string[] = []
 ): Promise<Array<string>> {
-  let cwd = repository.rootUri.fspath;
+  const cwd = repository.rootUri.fsPath;
   const cmd = "diff-index";
   const fullOptions = [
     "--name-status",

--- a/src/git/cli.ts
+++ b/src/git/cli.ts
@@ -36,7 +36,10 @@ async function _diffIndex(
   repository: Repository,
   options: string[] = []
 ): Promise<Array<string>> {
-  const cwd = repository.rootUri.path;
+  let cwd = repository.rootUri.path;
+  // Hack to make handle Windows path from rootUri, since it should not appear as a root path.
+  cwd = cwd.replace("/c:/", "c:/");
+
   const cmd = "diff-index";
   const fullOptions = [
     "--name-status",


### PR DESCRIPTION
Resolves #93 