### PR TITLE
Switch to double quotes for escaping

### DIFF
--- a/src/git/cli.ts
+++ b/src/git/cli.ts
@@ -11,7 +11,7 @@ const exec = util.promisify(_exec);
 
 // Ensure Git will show special characters literally without quoting the string
 // and escaping characters.
-const QUOTE_PATH = "-c 'core.quotePath=false'";
+const QUOTE_PATH = '-c "core.quotePath=false"';
 
 const DIFF_INDEX_CMD = "diff-index";
 const DIFF_INDEX_OPTIONS = [


### PR DESCRIPTION
When the extension runs in Windows, for cli commands CMD is used. CMD does not treat single quotes as a special character which causes problems